### PR TITLE
Make getEntityFromRequest public

### DIFF
--- a/src/CrudService.php
+++ b/src/CrudService.php
@@ -27,7 +27,7 @@ class CrudService {
         return new $this->entityClass();
     }
 
-    protected function getEntityFromRequest(Request $request): ?AbstractEntity {
+    public function getEntityFromRequest(Request $request): ?AbstractEntity {
         $id = $request->getAttribute("route_params")["id"];
         if (!is_numeric($id)) {
             return null;


### PR DESCRIPTION
Sometimes you want to get the Entity, and can use `read` however this may do other things that we don't want.