### PR TITLE
Kill depth concept on getAPIResponse

### DIFF
--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -42,7 +42,6 @@ abstract class AbstractEntity extends BaseEntity {
     /**
      * Generates the API response representation of this entity.
      *
-     * Handles nested entities up to a maximum depth of 3 to prevent circular references.
      * DateTime objects are formatted according to their type (date or date_time).
      *
      * @param AbstractEntity|null $parentEntity Parent entity to detect circular references

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -65,7 +65,7 @@ abstract class AbstractEntity extends BaseEntity {
                     continue;
                 }
 
-                $value = $value->getAPIResponse($parentEntity ?: $this);
+                $value = $value->getAPIResponse( $this);
             }
             else if ($value instanceof EntityCollection) {
                 if ($parentEntity && $mapping[$column]["entity"] === $parentEntity::class) {
@@ -75,7 +75,7 @@ abstract class AbstractEntity extends BaseEntity {
                 $entities = $value;
                 $value = [];
                 foreach ($entities as $entity) {
-                    $entityResponse = $entity->getAPIResponse($parentEntity ?: $this);
+                    $entityResponse = $entity->getAPIResponse($this);
                     $entityResponse["_links"] = $entity->getAPILinks();
                     $value[] = $entityResponse;
                 }

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -61,7 +61,7 @@ abstract class AbstractEntity extends BaseEntity {
                 $entities = $value;
                 $value = [];
                 foreach ($entities as $entity) {
-                    $entityResponse = $item->getAPIResponse($parentEntity ?: $this);
+                    $entityResponse = $entity->getAPIResponse($parentEntity ?: $this);
                     $entityResponse["_links"] = $entity->getAPILinks();
                     $value[] = $entityResponse;
                 }

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -68,7 +68,7 @@ abstract class AbstractEntity extends BaseEntity {
                 $value = $value->getAPIResponse($parentEntity ?: $this);
             }
             else if ($value instanceof EntityCollection) {
-                if ($value[0] instanceof $parentEntity) {
+                if ($mapping[$column]["entity"] === $parentEntity::class) {
                     continue;
                 }
 

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -68,7 +68,7 @@ abstract class AbstractEntity extends BaseEntity {
                 $value = $value->getAPIResponse($parentEntity ?: $this);
             }
             else if ($value instanceof EntityCollection) {
-                if ($mapping[$column]["entity"] === $parentEntity::class) {
+                if ($parentEntity && $mapping[$column]["entity"] === $parentEntity::class) {
                     continue;
                 }
 

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -32,7 +32,7 @@ abstract class AbstractEntity extends BaseEntity {
         return new static::$crudService(static::class);
     }
 
-    public function getAPIResponse(int $depth = 1, ?AbstractEntity $parentEntity = null): array {
+    public function getAPIResponse(?AbstractEntity $parentEntity = null): array {
         $response = [
             "id" => $this->getId(),
         ];
@@ -47,21 +47,21 @@ abstract class AbstractEntity extends BaseEntity {
             $value = $value["value"];
 
             if ($value instanceof self) {
-                if ($depth > 2 || $parentEntity === $value) {
+                if ($parentEntity === $value) {
                     continue;
                 }
 
-                $value = $value->getAPIResponse($depth + 1, $this);
+                $value = $value->getAPIResponse($parentEntity ?: $this);
             }
             else if ($value instanceof EntityCollection) {
-                if ($depth > 2) {
+                if ($value[0] instanceof $parentEntity) {
                     continue;
                 }
 
                 $items = $value;
                 $value = [];
                 foreach ($items as $item) {
-                    $itemResponse = $item->getAPIResponse($depth + 1, $this);
+                    $itemResponse = $item->getAPIResponse($parentEntity ?: $this);
                     $itemResponse["_links"] = $item->getAPILinks();
                     $value[] = $itemResponse;
                 }

--- a/src/AbstractEntity.php
+++ b/src/AbstractEntity.php
@@ -65,7 +65,7 @@ abstract class AbstractEntity extends BaseEntity {
                     continue;
                 }
 
-                $value = $value->getAPIResponse( $this);
+                $value = $value->getAPIResponse($this);
             }
             else if ($value instanceof EntityCollection) {
                 if ($parentEntity && $mapping[$column]["entity"] === $parentEntity::class) {


### PR DESCRIPTION
Just output what is currently loaded. Unless it has picked up the same model as first parent.